### PR TITLE
Fixed import of collections abc for Python 3.3+

### DIFF
--- a/pyswagger/utils.py
+++ b/pyswagger/utils.py
@@ -9,7 +9,12 @@ import re
 import os
 import operator
 import functools
-import collections
+
+# import according to python version
+try:  # Python >= 3.3
+    from collections.abc import MutableMapping
+except ImportError:  # Python < 3.3 including Python 2
+    from collections import MutableMapping
 
 #TODO: accept varg
 def scope_compose(scope, name, sep=private.SCOPE_SEPARATOR):


### PR DESCRIPTION
Some modules previously available in `collections` are no longer imported implicitly, and `collections.abc` must be used. I encountered the issue while using Python 3.10 but as far as I can tell this has been an issue since Python 3.3.
